### PR TITLE
Switching MetaMaskButton to use as=a prop

### DIFF
--- a/packages/ConnectionBanner/src/index.js
+++ b/packages/ConnectionBanner/src/index.js
@@ -71,9 +71,14 @@ const NoNetwork = ({ noNetworkAvailableMessage }) => {
               </Flex>
             </Flex>
 
-            <Link href="https://metamask.io/" target="_blank">
-              <MetaMaskButton>Install MetaMask</MetaMaskButton>
-            </Link>
+            <MetaMaskButton
+              as="a"
+              href="https://metamask.io/"
+              target="_blank"
+              color={'white'}
+            >
+              Install MetaMask
+            </MetaMaskButton>
           </Flex>
         </Flash>
       ) : (


### PR DESCRIPTION
Blocked by https://github.com/ConsenSys/rimble-ui/issues/271